### PR TITLE
Add live transcription section to UI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -49,11 +49,17 @@
   button:disabled{opacity:.6; cursor:not-allowed}
   .panel{padding:12px; border:1px dashed #26303a; border-radius:8px; background:#0a0d11}
   .section{color:#a7e8a7; margin:2px 0 8px; font-weight:900; letter-spacing:.5px}
+  .subsection{color:#9ad39a; margin-bottom:6px; font-weight:800; font-size:12px; text-transform:uppercase; letter-spacing:.4px}
   .muted{color:#7aa07a}
   .hint{color:#7aa07a}
   .kbd{display:inline-block; padding:4px 8px; background:#0d1215; border:1px solid #26323a; border-radius:6px; font-weight:700; font-size:12px}
   .code{background:#0a0d10; line-height:1.45; white-space:pre; overflow:auto}
   .badge{display:inline-block; padding:2px 8px; border:1px solid #244; border-radius:999px; font-size:12px; color:#a6cfa6; background:#0b1012}
+  .transcript-grid{display:grid; gap:12px; grid-template-columns:repeat(auto-fit, minmax(180px,1fr)); align-items:start}
+  .transcript-stream{min-height:140px; border:1px solid #1f252d; border-radius:6px; padding:10px; background:#080b0f; font-size:13px; line-height:1.45; white-space:pre-wrap; word-break:break-word}
+  .transcript-line{margin-bottom:8px; opacity:.85; transition:opacity .3s ease}
+  .transcript-line.final{opacity:1}
+  .transcript-line::before{content:""; display:block; height:2px; width:24px; margin-bottom:6px; background:linear-gradient(90deg, rgba(54,211,153,.2), transparent)}
   /* retro accordion */
   .accordion {border:1px solid var(--border); border-radius:8px; background:#0b0e12;}
   .acc-head{
@@ -171,6 +177,21 @@
           </div>
         </div>
 
+        <div class="panel" id="transcriptPanel" style="margin-top:16px">
+          <div class="section">Live transcription</div>
+          <div class="muted" id="transcriptStatus">Waiting for connection…</div>
+          <div class="transcript-grid" style="margin-top:12px">
+            <div>
+              <div class="subsection">Caller</div>
+              <div id="userTranscript" class="transcript-stream"></div>
+            </div>
+            <div>
+              <div class="subsection">Agent</div>
+              <div id="agentTranscript" class="transcript-stream"></div>
+            </div>
+          </div>
+        </div>
+
       </div> <!-- /content -->
     </div>   <!-- /crt-box -->
   </div>     <!-- /wrap -->
@@ -274,6 +295,83 @@ $("copyTwiml").onclick = async () => {
   try { await navigator.clipboard.writeText($("twiml").textContent); setText("genMsg","Copied TwiML"); setTimeout(()=>setText("genMsg",""),1200); }
   catch { setText("genMsg","Copy failed"); }
 };
+
+/* Live transcript UI */
+const transcriptContainers = {
+  user: $("userTranscript"),
+  agent: $("agentTranscript")
+};
+const transcriptState = {
+  user: { entries: new Map(), lastId: null },
+  agent: { entries: new Map(), lastId: null }
+};
+const transcriptStatus = $("transcriptStatus");
+let transcriptRetry;
+
+function renderTranscript(role, id, text, { append = true, final = false } = {}) {
+  const container = transcriptContainers[role];
+  if (!container) return;
+
+  const store = transcriptState[role];
+  let key = id;
+  if (!key) {
+    key = append && store.lastId ? store.lastId : `${role}-${Date.now()}`;
+  }
+
+  let entry = store.entries.get(key);
+  if (!entry) {
+    const el = document.createElement("div");
+    el.className = "transcript-line";
+    container.appendChild(el);
+    entry = { el, text: "" };
+    store.entries.set(key, entry);
+  }
+
+  if (typeof text === "string" && text.length) {
+    entry.text = append ? entry.text + text : text;
+    entry.el.textContent = entry.text.trim();
+  }
+
+  if (final) entry.el.classList.add("final");
+
+  store.lastId = key;
+}
+
+function connectTranscriptStream() {
+  clearTimeout(transcriptRetry);
+  const scheme = location.protocol === "https:" ? "wss" : "ws";
+  const ws = new WebSocket(`${scheme}://${location.host}/transcripts`);
+  transcriptStatus.textContent = "Connecting to transcription…";
+
+  ws.onopen = () => {
+    transcriptStatus.textContent = "Live transcription active.";
+  };
+
+  ws.onclose = () => {
+    transcriptStatus.textContent = "Disconnected. Reconnecting…";
+    transcriptRetry = setTimeout(connectTranscriptStream, 2500);
+  };
+
+  ws.onerror = () => {
+    transcriptStatus.textContent = "Transcription connection error.";
+  };
+
+  ws.onmessage = (event) => {
+    let data;
+    try { data = JSON.parse(event.data); } catch { return; }
+    if (data.type === "status" && data.status) {
+      transcriptStatus.textContent = data.status === "connected" ? "Live transcription ready." : data.status;
+      return;
+    }
+    if (data.type !== "transcript" || !data.role) return;
+    renderTranscript(data.role === "agent" ? "agent" : "user", data.id, data.text, {
+      append: data.append !== false,
+      final: Boolean(data.final)
+    });
+  };
+}
+
+connectTranscriptStream();
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a websocket channel that broadcasts agent and caller transcript events to browsers
- render a live transcription panel that streams caller and agent text at the bottom of the UI

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68d8a88bb5d08320904d003000711a91