### PR TITLE
Gate noise suppression by model allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,7 @@ NGROK_AUTHTOKEN=xxxxxxxxxxxxxxxxxxxxxxxxxxxx       # from https://dashboard.ngro
 PORT=8080
 APP_BASE_URL=                    # leave blank; start script will fill with https://<ngrok>.ngrok-free.app
 LOG_LEVEL=info                   # debug | info | warn | error
+
+# --- Optional model feature allowlists (comma-separated model IDs) ---
+OPENAI_TRANSCRIPTION_MODELS=
+OPENAI_NOISE_SUPPRESSION_MODELS=

--- a/readme.md
+++ b/readme.md
@@ -13,3 +13,18 @@ A tiny starter that lets anyone paste **custom instructions**, choose a **voice*
 cp .env.example .env   # or: npm run setup (guided)
 npm i
 npm run start:ngrok    # prints the public https URL; open it
+```
+
+## Optional model feature allowlists
+
+Some realtime capabilities are only available on certain models. To avoid
+unexpected errors you can opt-in model IDs via environment variables (comma
+separated):
+
+| Variable | Purpose |
+| --- | --- |
+| `OPENAI_TRANSCRIPTION_MODELS` | Enables `input_audio_transcription` when the selected realtime model is included. Leave empty to fall back to the default detection for `gpt-4o-realtime-preview*`. |
+| `OPENAI_NOISE_SUPPRESSION_MODELS` | Enables `session.audio.input.noise_suppression` for the listed realtime models. Leave empty to allow the default `gpt-4o-realtime-preview*` detection. |
+
+Define these in your `.env` (see `.env.example`) when using compatible models to
+activate the corresponding features.


### PR DESCRIPTION
## Summary
- add a configurable allowlist to control which realtime models receive input noise suppression settings
- skip sending the noise suppression block when the selected model is not allowlisted while keeping turn detection enabled
- document the new OPENAI_NOISE_SUPPRESSION_MODELS variable alongside the transcription allowlist and surface both in .env.example

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9aea56a348320afda8e5b4ecbba6d